### PR TITLE
Install verilator, build pycoreir from source

### DIFF
--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -1,13 +1,19 @@
 FROM ubuntu:18.04 as magma_image
 
 RUN \
-    apt-get update && apt-get install -yq python3 python3-pip python3-venv build-essential git cmake libmpfr-dev libmpc-dev && \
+    apt-get update && apt-get install -yq python3 python3-pip python3-venv build-essential git cmake libmpfr-dev libmpc-dev verilator && \
     apt-get clean && \
     python3 -m venv stanford
 
 
 RUN \
     bash -c "source stanford/bin/activate && pip install --upgrade pip && pip install wheel pytest magma-lang dataclasses mantle"
+
+RUN \
+    bash -c "git clone https://github.com/leonardt/pycoreir"
+
+RUN \
+    bash -c "source stanford/bin/activate && cd pycoreir && pip install -e ."
 
 RUN \
     bash -c "git clone https://github.com/phanrahan/magma"


### PR DESCRIPTION
It seems that the pip distribution `pycoreir` isn't compatible with the docker environment, this provides a workaround by building pycoreir from source. It also adds the verilator package which is required by the magma tests.

We will investigate the pycoreir issue.